### PR TITLE
Add runtime Bluesky status API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ CRON_SECRET=
 # Optional cron override (default: 0 7,11,14,17,21 * * *)
 # 7am, 11am, 2pm, 5pm, 9pm
 # SYNC_CRON=0 7,11,14,17,21 * * *
+
+# Bluesky app password for `pnpm status` (not used by the web server)
+BLUESKY_HANDLE=michaelschultz.com
+BLUESKY_APP_PASSWORD=

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@
 
 - SvelteKit site at the repo root: `@sveltejs/adapter-node` (hybrid — most routes prerendered, `/listening` is SSR), mdsvex (`.svx` in `src/content/thoughts/`), and `$lib/content/*` plus `$lib/config/*` for posts, work, games, and site config.
 - `/listening` reads recent Last.fm scrobbles from SQLite (`better-sqlite3`); sync runs via in-process `node-cron` (~5×/day at server startup) and stale refresh on page load; `GET /api/cron/sync-listening` (Bearer `CRON_SECRET`) is optional for external/manual HTTP sync only.
+- Homepage status line reads `com.michaelschultz.status/self` from Bluesky via `/api/status` (60s server cache); publish with `pnpm status` using `BLUESKY_APP_PASSWORD` locally (not needed at runtime).
 - Docker deployment: `Dockerfile` + `docker-compose.yml`; joins an external Docker network for reverse-proxy routing; SQLite DB at `DATABASE_PATH` (default `/app/data/listening.db` in Docker); `deploy/docker-entrypoint.sh` chowns the `listening-data` volume for SQLite writes.
 - Production deploy is automated via `.github/workflows/deploy.yml` (SSH pull + `deploy/write-env.sh` + `deploy/deploy.sh`); app and infrastructure settings live in GitHub Environment secrets, not in the repo.
 - Static assets live under `static/static/` so URLs stay `/static/images/...`.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # michaelschultz.com
 
-Personal site of [Michael Schultz](https://michaelschultz.com) — portfolio, writing, projects, and a live [/listening](https://michaelschultz.com/listening) page backed by Last.fm.
+Personal site of [Michael Schultz](https://michaelschultz.com) — portfolio, writing, projects, a live [/listening](https://michaelschultz.com/listening) page backed by Last.fm, and a Bluesky-powered status line on the homepage.
 
-Built with **SvelteKit**, **Tailwind CSS**, and **mdsvex** for markdown posts. Most pages are prerendered; `/listening` is server-rendered and backed by SQLite.
+Built with **SvelteKit**, **Tailwind CSS**, and **mdsvex** for markdown posts. Most pages are prerendered; `/listening` and `/api/status` are server-rendered at request time.
 
 ## Local development
 
@@ -40,6 +40,8 @@ Copy `.env.example` to `.env` for local development:
 | `LASTFM_USER` | Last.fm username (default: `michaelschultz`) |
 | `DATABASE_PATH` | SQLite path (default: `./data/listening.db`) |
 | `CRON_SECRET` | Optional bearer token for `GET /api/cron/sync-listening` |
+| `BLUESKY_APP_PASSWORD` | Bluesky app password for `pnpm status` (optional) |
+| `BLUESKY_HANDLE` | Bluesky handle for `pnpm status` (default: `michaelschultz.com`) |
 
 The listening page syncs recent plays from Last.fm into SQLite on a schedule and when the cache is stale. An in-process cron job handles most updates; `CRON_SECRET` is only needed if you want to trigger syncs over HTTP.
 
@@ -48,6 +50,16 @@ Manual sync while the dev server is running:
 ```bash
 pnpm sync:listening
 ```
+
+## Bluesky status
+
+The homepage reads a short status sentence from a Bluesky record (`com.michaelschultz.status/self`) via `/api/status`. Publish updates locally:
+
+```bash
+pnpm status "Shipping something new"
+```
+
+Create an app password in Bluesky settings. The lexicon schema lives in `lexicons/com.michaelschultz.status.json`.
 
 ## Docker
 
@@ -68,4 +80,5 @@ Production configuration for this site is managed outside the repo (GitHub Envir
 - `src/content/thoughts/` — blog posts (`.svx`)
 - `src/lib/content/` — work, games, and post metadata
 - `src/lib/listening/` — Last.fm sync and SQLite cache
+- `src/lib/bluesky/` — Bluesky status fetch + cache
 - `deploy/` — deployment scripts

--- a/lexicons/com.michaelschultz.status.json
+++ b/lexicons/com.michaelschultz.status.json
@@ -1,0 +1,32 @@
+{
+	"lexicon": 1,
+	"id": "com.michaelschultz.status",
+	"defs": {
+		"main": {
+			"type": "record",
+			"description": "A short sentence describing what Michael is doing right now.",
+			"key": "literal:self",
+			"record": {
+				"type": "object",
+				"required": ["text", "createdAt"],
+				"properties": {
+					"text": {
+						"type": "string",
+						"maxLength": 280,
+						"maxGraphemes": 140,
+						"description": "A brief status sentence."
+					},
+					"createdAt": {
+						"type": "string",
+						"format": "datetime"
+					},
+					"expiresAt": {
+						"type": "string",
+						"format": "datetime",
+						"description": "Optional time after which the status should no longer be shown."
+					}
+				}
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
 		"start": "node build",
 		"preview": "node build",
 		"sync:listening": "node scripts/sync-listening.mjs",
+		"status": "node scripts/set-status.mjs",
 		"prepare": "svelte-kit sync || echo '' && (command -v husky >/dev/null 2>&1 && husky || true)",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json && tsc --noEmit",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
 	},
 	"devDependencies": {
+		"@atproto/api": "^0.15.15",
 		"@sveltejs/adapter-node": "^5.5.7",
 		"@sveltejs/kit": "^2.57.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
         specifier: ^0.0.23
         version: 0.0.23
     devDependencies:
+      '@atproto/api':
+        specifier: ^0.15.15
+        version: 0.15.27
       '@sveltejs/adapter-node':
         specifier: ^5.5.7
         version: 5.5.7(@sveltejs/kit@2.61.1(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.0)(vite@8.0.14(@types/node@24.12.4)(jiti@1.21.7)))(svelte@5.56.0)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(jiti@1.21.7)))
@@ -84,6 +87,33 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@atproto/api@0.15.27':
+    resolution: {integrity: sha512-ok/WGafh1nz4t8pEQGtAF/32x2E2VDWU4af6BajkO5Gky2jp2q6cv6aB2A5yuvNNcc3XkYMYipsqVHVwLPMF9g==}
+
+  '@atproto/common-web@0.4.21':
+    resolution: {integrity: sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw==}
+
+  '@atproto/lex-data@0.0.15':
+    resolution: {integrity: sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw==}
+
+  '@atproto/lex-json@0.0.16':
+    resolution: {integrity: sha512-IgLgQ0krshVlrIYZ+heTBDbCnM3LmAgWvsaYn5MxvKA3LcBot3PG3ptdO8VOweVZ+WgCLuo39cz9EbUmIbqdtg==}
+
+  '@atproto/lexicon@0.4.14':
+    resolution: {integrity: sha512-jiKpmH1QER3Gvc7JVY5brwrfo+etFoe57tKPQX/SmPwjvUsFnJAow5xLIryuBaJgFAhnTZViXKs41t//pahGHQ==}
+
+  '@atproto/lexicon@0.6.2':
+    resolution: {integrity: sha512-p3Ly6hinVZW0ETuAXZMeUGwuMm3g8HvQMQ41yyEE6AL0hAkfeKFaZKos6BdBrr6CjkpbrDZqE8M+5+QOceysMw==}
+
+  '@atproto/syntax@0.4.3':
+    resolution: {integrity: sha512-YoZUz40YAJr5nPwvCDWgodEOlt5IftZqPJvA0JDWjuZKD8yXddTwSzXSaKQAzGOpuM+/A3uXRtPzJJqlScc+iA==}
+
+  '@atproto/syntax@0.5.4':
+    resolution: {integrity: sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==}
+
+  '@atproto/xrpc@0.7.7':
+    resolution: {integrity: sha512-K1ZyO/BU8JNtXX5dmPp7b5UrkLMMqpsIa/Lrj5D3Su+j1Xwq1m6QJ2XJ1AgjEjkI1v4Muzm7klianLE6XGxtmA==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -646,6 +676,9 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  await-lock@2.2.2:
+    resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
+
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
@@ -884,6 +917,9 @@ packages:
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
+  iso-datestring-validator@2.2.2:
+    resolution: {integrity: sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA==}
+
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -1017,6 +1053,9 @@ packages:
   mrmime@2.0.1:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
+
+  multiformats@9.9.0:
+    resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
 
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -1297,6 +1336,10 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
+  tlds@1.261.0:
+    resolution: {integrity: sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -1319,8 +1362,14 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uint8arrays@3.0.0:
+    resolution: {integrity: sha512-HRCx0q6O9Bfbp+HHSfQQKD7wU70+lydKVt4EghkdOvlK/NlrF90z+eXV34mUd48rNvVJXwkrMSPpCATkct8fJA==}
+
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
+
+  unicode-segmenter@0.14.5:
+    resolution: {integrity: sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g==}
 
   unist-util-is@4.1.0:
     resolution: {integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==}
@@ -1403,9 +1452,71 @@ packages:
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@atproto/api@0.15.27':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/lexicon': 0.4.14
+      '@atproto/syntax': 0.4.3
+      '@atproto/xrpc': 0.7.7
+      await-lock: 2.2.2
+      multiformats: 9.9.0
+      tlds: 1.261.0
+      zod: 3.25.76
+
+  '@atproto/common-web@0.4.21':
+    dependencies:
+      '@atproto/lex-data': 0.0.15
+      '@atproto/lex-json': 0.0.16
+      '@atproto/syntax': 0.5.4
+      zod: 3.25.76
+
+  '@atproto/lex-data@0.0.15':
+    dependencies:
+      multiformats: 9.9.0
+      tslib: 2.8.1
+      uint8arrays: 3.0.0
+      unicode-segmenter: 0.14.5
+
+  '@atproto/lex-json@0.0.16':
+    dependencies:
+      '@atproto/lex-data': 0.0.15
+      tslib: 2.8.1
+
+  '@atproto/lexicon@0.4.14':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/syntax': 0.4.3
+      iso-datestring-validator: 2.2.2
+      multiformats: 9.9.0
+      zod: 3.25.76
+
+  '@atproto/lexicon@0.6.2':
+    dependencies:
+      '@atproto/common-web': 0.4.21
+      '@atproto/syntax': 0.5.4
+      iso-datestring-validator: 2.2.2
+      multiformats: 9.9.0
+      zod: 3.25.76
+
+  '@atproto/syntax@0.4.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@atproto/syntax@0.5.4':
+    dependencies:
+      tslib: 2.8.1
+
+  '@atproto/xrpc@0.7.7':
+    dependencies:
+      '@atproto/lexicon': 0.6.2
+      zod: 3.25.76
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -1828,6 +1939,8 @@ snapshots:
       postcss: 8.5.15
       postcss-value-parser: 4.2.0
 
+  await-lock@2.2.2: {}
+
   axobject-query@4.1.0: {}
 
   base64-js@1.5.1: {}
@@ -2024,6 +2137,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  iso-datestring-validator@2.2.2: {}
+
   jiti@1.21.7: {}
 
   jiti@2.7.0: {}
@@ -2117,6 +2232,8 @@ snapshots:
   mri@1.2.0: {}
 
   mrmime@2.0.1: {}
+
+  multiformats@9.9.0: {}
 
   mz@2.7.0:
     dependencies:
@@ -2465,6 +2582,8 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tlds@1.261.0: {}
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -2473,8 +2592,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tunnel-agent@0.6.0:
     dependencies:
@@ -2482,7 +2600,13 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  uint8arrays@3.0.0:
+    dependencies:
+      multiformats: 9.9.0
+
   undici-types@7.16.0: {}
+
+  unicode-segmenter@0.14.5: {}
 
   unist-util-is@4.1.0: {}
 
@@ -2533,3 +2657,5 @@ snapshots:
   wrappy@1.0.2: {}
 
   zimmerframe@1.1.4: {}
+
+  zod@3.25.76: {}

--- a/scripts/load-env.mjs
+++ b/scripts/load-env.mjs
@@ -1,0 +1,33 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Load `.env` from the repo root without overriding existing environment variables. */
+export function loadEnvFile() {
+	const path = join(root, '.env');
+	if (!existsSync(path)) return;
+
+	for (const line of readFileSync(path, 'utf8').split('\n')) {
+		const trimmed = line.trim();
+		if (!trimmed || trimmed.startsWith('#')) continue;
+
+		const separator = trimmed.indexOf('=');
+		if (separator === -1) continue;
+
+		const key = trimmed.slice(0, separator).trim();
+		let value = trimmed.slice(separator + 1).trim();
+
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
+
+		if (!(key in process.env)) {
+			process.env[key] = value;
+		}
+	}
+}

--- a/scripts/postbuild.mjs
+++ b/scripts/postbuild.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url';
 
 const projectRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
 
-execSync('pagefind --site build --output-subdir pagefind', {
+execSync('pagefind --site build/prerendered --output-path build/client/pagefind', {
 	stdio: 'inherit',
 	cwd: projectRoot
 });

--- a/scripts/set-status.mjs
+++ b/scripts/set-status.mjs
@@ -1,0 +1,33 @@
+import { BskyAgent } from '@atproto/api';
+
+const COLLECTION = 'com.michaelschultz.status';
+const text = process.argv.slice(2).join(' ').trim();
+
+if (!text) {
+	console.error('Usage: pnpm status "Your status text"');
+	process.exit(1);
+}
+
+const handle = process.env.BLUESKY_HANDLE ?? 'michaelschultz.com';
+const password = process.env.BLUESKY_APP_PASSWORD;
+
+if (!password) {
+	console.error('Set BLUESKY_APP_PASSWORD to a Bluesky app password.');
+	process.exit(1);
+}
+
+const agent = new BskyAgent({ service: 'https://bsky.social' });
+await agent.login({ identifier: handle, password });
+
+await agent.com.atproto.repo.putRecord({
+	repo: agent.did,
+	collection: COLLECTION,
+	rkey: 'self',
+	record: {
+		$type: COLLECTION,
+		text,
+		createdAt: new Date().toISOString()
+	}
+});
+
+console.log(`Status updated for @${handle}: ${text}`);

--- a/scripts/set-status.mjs
+++ b/scripts/set-status.mjs
@@ -1,4 +1,7 @@
 import { BskyAgent } from '@atproto/api';
+import { loadEnvFile } from './load-env.mjs';
+
+loadEnvFile();
 
 const COLLECTION = 'com.michaelschultz.status';
 const text = process.argv.slice(2).join(' ').trim();

--- a/scripts/sync-listening.mjs
+++ b/scripts/sync-listening.mjs
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+import { loadEnvFile } from './load-env.mjs';
+
+loadEnvFile();
+
 const url = process.env.SYNC_URL ?? 'http://127.0.0.1:3000/api/cron/sync-listening';
 const secret = process.env.CRON_SECRET;
 

--- a/src/lib/bluesky/status.ts
+++ b/src/lib/bluesky/status.ts
@@ -1,0 +1,85 @@
+import { bluesky } from '$lib/config/bluesky';
+
+export type BlueskyStatus = {
+	text: string;
+	createdAt: string;
+	expiresAt?: string;
+};
+
+type StatusRecord = BlueskyStatus & {
+	$type: string;
+};
+
+type GetRecordResponse = {
+	value: StatusRecord;
+};
+
+type CacheEntry = {
+	status: BlueskyStatus | null;
+	fetchedAt: number;
+};
+
+let cache: CacheEntry | null = null;
+
+function isStatusRecord(value: unknown): value is StatusRecord {
+	if (!value || typeof value !== 'object') return false;
+	const record = value as StatusRecord;
+	return typeof record.text === 'string' && typeof record.createdAt === 'string';
+}
+
+function isExpired(status: BlueskyStatus): boolean {
+	if (!status.expiresAt) return false;
+	return Date.now() > new Date(status.expiresAt).getTime();
+}
+
+function toStatus(record: StatusRecord): BlueskyStatus {
+	return {
+		text: record.text,
+		createdAt: record.createdAt,
+		...(record.expiresAt ? { expiresAt: record.expiresAt } : {})
+	};
+}
+
+async function fetchStatusFromBluesky(): Promise<BlueskyStatus | null> {
+	const url = new URL('/xrpc/com.atproto.repo.getRecord', bluesky.apiBase);
+	url.searchParams.set('repo', bluesky.handle);
+	url.searchParams.set('collection', bluesky.statusCollection);
+	url.searchParams.set('rkey', bluesky.statusRkey);
+
+	const response = await fetch(url);
+
+	if (!response.ok) {
+		const body = (await response.json().catch(() => null)) as { error?: string } | null;
+		if (body?.error === 'RecordNotFound') {
+			return null;
+		}
+		throw new Error(`Bluesky API error: ${response.status}`);
+	}
+
+	const data = (await response.json()) as GetRecordResponse;
+	if (!isStatusRecord(data.value)) {
+		return null;
+	}
+
+	const status = toStatus(data.value);
+	return isExpired(status) ? null : status;
+}
+
+/** Fetch the current Bluesky status, with a short in-memory cache. */
+export async function getBlueskyStatus(): Promise<BlueskyStatus | null> {
+	const now = Date.now();
+	if (cache && now - cache.fetchedAt < bluesky.cacheTtlMs) {
+		return cache.status;
+	}
+
+	try {
+		const status = await fetchStatusFromBluesky();
+		cache = { status, fetchedAt: now };
+		return status;
+	} catch (error) {
+		if (cache) {
+			return cache.status;
+		}
+		throw error;
+	}
+}

--- a/src/lib/bluesky/status.ts
+++ b/src/lib/bluesky/status.ts
@@ -52,6 +52,11 @@ function toStatus(record: StatusRecord): BlueskyStatus {
 	};
 }
 
+function activeStatus(status: BlueskyStatus | null): BlueskyStatus | null {
+	if (!status || isExpired(status)) return null;
+	return status;
+}
+
 async function resolveDid(repo: string): Promise<string> {
 	if (repo.startsWith('did:')) return repo;
 
@@ -125,7 +130,7 @@ async function fetchStatusFromBluesky(): Promise<BlueskyStatus | null> {
 export async function getBlueskyStatus(): Promise<BlueskyStatus | null> {
 	const now = Date.now();
 	if (cache && now - cache.fetchedAt < bluesky.cacheTtlMs) {
-		return cache.status;
+		return activeStatus(cache.status);
 	}
 
 	try {
@@ -134,7 +139,7 @@ export async function getBlueskyStatus(): Promise<BlueskyStatus | null> {
 		return status;
 	} catch (error) {
 		if (cache) {
-			return cache.status;
+			return activeStatus(cache.status);
 		}
 		throw error;
 	}

--- a/src/lib/bluesky/status.ts
+++ b/src/lib/bluesky/status.ts
@@ -19,6 +19,18 @@ type CacheEntry = {
 	fetchedAt: number;
 };
 
+type DescribeRepoResponse = {
+	didDoc?: {
+		service?: Array<{
+			id?: string;
+			type?: string;
+			serviceEndpoint?: string;
+		}>;
+	};
+};
+
+const relay = bluesky.relay;
+
 let cache: CacheEntry | null = null;
 
 function isStatusRecord(value: unknown): value is StatusRecord {
@@ -40,9 +52,53 @@ function toStatus(record: StatusRecord): BlueskyStatus {
 	};
 }
 
+async function resolveDid(repo: string): Promise<string> {
+	if (repo.startsWith('did:')) return repo;
+
+	const url = new URL('/xrpc/com.atproto.identity.resolveHandle', relay);
+	url.searchParams.set('handle', repo);
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(`Failed to resolve Bluesky handle: ${response.status}`);
+	}
+
+	const data = (await response.json()) as { did?: string };
+	if (!data.did) {
+		throw new Error('Bluesky handle did not resolve to a DID');
+	}
+
+	return data.did;
+}
+
+async function resolvePdsEndpoint(did: string): Promise<string> {
+	const url = new URL('/xrpc/com.atproto.repo.describeRepo', relay);
+	url.searchParams.set('repo', did);
+
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(`Failed to describe Bluesky repo: ${response.status}`);
+	}
+
+	const data = (await response.json()) as DescribeRepoResponse;
+	const pds = data.didDoc?.service?.find(
+		(service) => service.id === '#atproto_pds' || service.type === 'AtprotoPersonalDataServer'
+	);
+	const endpoint = pds?.serviceEndpoint?.replace(/\/$/, '');
+
+	if (!endpoint) {
+		throw new Error('Bluesky PDS endpoint not found');
+	}
+
+	return endpoint;
+}
+
 async function fetchStatusFromBluesky(): Promise<BlueskyStatus | null> {
-	const url = new URL('/xrpc/com.atproto.repo.getRecord', bluesky.apiBase);
-	url.searchParams.set('repo', bluesky.handle);
+	const did = await resolveDid(bluesky.handle);
+	const pds = await resolvePdsEndpoint(did);
+
+	const url = new URL('/xrpc/com.atproto.repo.getRecord', pds);
+	url.searchParams.set('repo', did);
 	url.searchParams.set('collection', bluesky.statusCollection);
 	url.searchParams.set('rkey', bluesky.statusRkey);
 

--- a/src/lib/components/Hero.svelte
+++ b/src/lib/components/Hero.svelte
@@ -1,3 +1,7 @@
+<script lang="ts">
+	import StatusLine from '$lib/components/StatusLine.svelte';
+</script>
+
 <div class="relative min-h-[500px] overflow-hidden rounded-md bg-[#6D962A] p-6 md:p-10 lg:min-h-0">
 	<h1
 		class="font-hero fade-in-down-headline text-5xl font-bold uppercase tracking-tighter text-[#DBE8A8] opacity-0 md:text-[114px] lg:leading-[114px] xl:text-[168px] xl:leading-[168px]"
@@ -5,11 +9,12 @@
 		Michael Schultz
 	</h1>
 	<div class="flex">
-		<p
-			class="fade-in-down pr-20 pt-10 text-[#042C0E] opacity-0 md:max-w-[300px] md:pt-24 xl:whitespace-pre"
-		>
-			{`Software designer and engineer \nwith a passion for creating— \nfrom innovative web \nsolutions to video games, \nmusic, and impactful \nsoftware projects.`}
-		</p>
+		<div class="pr-20 pt-10 md:max-w-[300px] md:pt-24">
+			<p class="fade-in-down text-[#042C0E] opacity-0 xl:whitespace-pre">
+				{`Software designer and engineer \nwith a passion for creating— \nfrom innovative web \nsolutions to video games, \nmusic, and impactful \nsoftware projects.`}
+			</p>
+			<StatusLine />
+		</div>
 		<img
 			src="/static/images/michael_fullbody.png"
 			alt="Michael Schultz"

--- a/src/lib/components/PagefindSearch.svelte
+++ b/src/lib/components/PagefindSearch.svelte
@@ -27,7 +27,7 @@
 			.catch(() => {
 				registerOpen(() => {
 					console.warn(
-						'Pagefind search is not available. Run `pnpm build` in web/ (or use `pnpm preview`) to generate the search index.'
+						'Pagefind search is not available. Run `pnpm build` once, then use `pnpm dev` or `pnpm preview`.'
 					);
 				});
 			});

--- a/src/lib/components/StatusLine.svelte
+++ b/src/lib/components/StatusLine.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type { BlueskyStatus } from '$lib/bluesky/status';
+
+	let status = $state<BlueskyStatus | null>(null);
+
+	onMount(async () => {
+		try {
+			const response = await fetch('/api/status');
+			if (!response.ok) return;
+
+			const data = (await response.json()) as { status: BlueskyStatus | null };
+			if (data.status) {
+				status = data.status;
+			}
+		} catch {
+			// Status is optional; fail silently.
+		}
+	});
+</script>
+
+{#if status}
+	<p class="fade-in-down mt-4 text-sm text-[#042C0E] opacity-0">
+		<span class="font-semibold">Now:</span>
+		{status.text}
+	</p>
+{/if}

--- a/src/lib/config/bluesky.ts
+++ b/src/lib/config/bluesky.ts
@@ -1,6 +1,7 @@
 export const bluesky = {
 	handle: 'michaelschultz.com',
-	apiBase: 'https://public.api.bsky.app',
+	/** Relay used to resolve handles and repo metadata before reading custom records from the PDS. */
+	relay: 'https://bsky.social',
 	statusCollection: 'com.michaelschultz.status',
 	statusRkey: 'self',
 	/** Server-side cache TTL when fetching status from Bluesky. */

--- a/src/lib/config/bluesky.ts
+++ b/src/lib/config/bluesky.ts
@@ -1,0 +1,8 @@
+export const bluesky = {
+	handle: 'michaelschultz.com',
+	apiBase: 'https://public.api.bsky.app',
+	statusCollection: 'com.michaelschultz.status',
+	statusRkey: 'self',
+	/** Server-side cache TTL when fetching status from Bluesky. */
+	cacheTtlMs: 60_000
+} as const;

--- a/src/lib/search/pagefind.ts
+++ b/src/lib/search/pagefind.ts
@@ -1,3 +1,5 @@
+import { goto } from '$app/navigation';
+
 type PagefindModal = HTMLElement & {
 	open: () => void;
 	close: () => void;
@@ -6,12 +8,30 @@ type PagefindModal = HTMLElement & {
 
 let loadPromise: Promise<void> | null = null;
 
+declare const __PAGEFIND_INDEX_BUILT__: boolean;
+
+async function pagefindIndexAvailable(): Promise<boolean> {
+	if (import.meta.env.DEV && !__PAGEFIND_INDEX_BUILT__) {
+		return false;
+	}
+
+	try {
+		const response = await fetch('/pagefind/pagefind-entry.json', { method: 'HEAD' });
+		return response.ok;
+	} catch {
+		return false;
+	}
+}
+
 export function loadPagefindComponentUi(): Promise<void> {
 	if (!loadPromise) {
-		loadPromise = new Promise((resolve, reject) => {
+		loadPromise = (async () => {
 			if (typeof document === 'undefined') {
-				reject(new Error('No document'));
-				return;
+				throw new Error('No document');
+			}
+
+			if (!(await pagefindIndexAvailable())) {
+				throw new Error('Pagefind index not found');
 			}
 
 			if (!document.querySelector('link[data-pagefind-ui-css]')) {
@@ -24,20 +44,22 @@ export function loadPagefindComponentUi(): Promise<void> {
 
 			const existing = document.querySelector('script[data-pagefind-ui-js]');
 			if (existing) {
-				customElements.whenDefined('pagefind-modal').then(() => resolve()).catch(reject);
+				await customElements.whenDefined('pagefind-modal');
 				return;
 			}
 
-			const script = document.createElement('script');
-			script.type = 'module';
-			script.src = '/pagefind/pagefind-component-ui.js';
-			script.dataset.pagefindUiJs = '';
-			script.onload = () => {
-				customElements.whenDefined('pagefind-modal').then(() => resolve()).catch(reject);
-			};
-			script.onerror = () => reject(new Error('Failed to load Pagefind UI'));
-			document.head.appendChild(script);
-		});
+			await new Promise<void>((resolve, reject) => {
+				const script = document.createElement('script');
+				script.type = 'module';
+				script.src = '/pagefind/pagefind-component-ui.js';
+				script.dataset.pagefindUiJs = '';
+				script.onload = () => {
+					customElements.whenDefined('pagefind-modal').then(() => resolve()).catch(reject);
+				};
+				script.onerror = () => reject(new Error('Failed to load Pagefind UI'));
+				document.head.appendChild(script);
+			});
+		})();
 	}
 
 	return loadPromise;
@@ -46,21 +68,65 @@ export function loadPagefindComponentUi(): Promise<void> {
 const RESULT_LINK_SELECTOR =
 	'a.pf-result-link, a.pf-searchbox-result, a.pf-heading-link, a.pf-searchbox-subresult';
 
+function withTrailingSlash(pathname: string): string {
+	if (pathname === '/') return '/';
+	return pathname.endsWith('/') ? pathname : `${pathname}/`;
+}
+
+function resolveInternalPath(href: string): string | null {
+	try {
+		const url = new URL(href, window.location.origin);
+		if (url.origin !== window.location.origin) return null;
+		return withTrailingSlash(url.pathname) + url.search + url.hash;
+	} catch {
+		return null;
+	}
+}
+
+function findResultLink(target: EventTarget | null, modal: PagefindModal): HTMLAnchorElement | null {
+	if (!(target instanceof Element)) return null;
+	const link = target.closest(RESULT_LINK_SELECTOR);
+	if (!(link instanceof HTMLAnchorElement) || !modal.contains(link)) return null;
+	return link;
+}
+
+function followResultLink(link: HTMLAnchorElement, modal: PagefindModal): void {
+	const href = link.getAttribute('href');
+	if (!href || href === '#' || href.startsWith('javascript:')) return;
+
+	modal.close();
+
+	const internalPath = resolveInternalPath(href);
+	if (internalPath !== null) {
+		void goto(internalPath);
+		return;
+	}
+
+	window.location.assign(href);
+}
+
 /** Close the search modal when the user follows a result link (click or Enter). */
 export function attachCloseOnResultNavigate(modal: PagefindModal): () => void {
-	const closeIfResultLink = (target: EventTarget | null) => {
-		if (!(target instanceof Element)) return;
-		const link = target.closest(RESULT_LINK_SELECTOR);
-		if (!link || !modal.contains(link)) return;
-		const href = link.getAttribute('href');
-		if (!href || href === '#' || href.startsWith('javascript:')) return;
-		modal.close();
+	const onClick = (event: MouseEvent) => {
+		if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+			return;
+		}
+
+		const link = findResultLink(event.target, modal);
+		if (!link) return;
+
+		event.preventDefault();
+		followResultLink(link, modal);
 	};
 
-	const onClick = (event: MouseEvent) => closeIfResultLink(event.target);
 	const onKeydown = (event: KeyboardEvent) => {
 		if (event.key !== 'Enter') return;
-		closeIfResultLink(event.target);
+
+		const link = findResultLink(event.target, modal);
+		if (!link) return;
+
+		event.preventDefault();
+		followResultLink(link, modal);
 	};
 
 	modal.addEventListener('click', onClick);

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -46,9 +46,14 @@
 <div class="mx-auto max-w-3xl px-4 sm:px-6 xl:max-w-5xl xl:px-0">
 	<div class="flex min-h-screen flex-col justify-between font-sans">
 		<SiteHeader onSearchClick={() => openSearch()} />
-		<main class="mb-auto" data-pagefind-body>
-			<span class="sr-only" data-pagefind-meta={`url:${pagefindUrl}`}
-			></span>
+		<main
+			class="mb-auto"
+			data-pagefind-body={pagefindUrl === '/' ? undefined : true}
+			data-pagefind-ignore={pagefindUrl === '/' ? 'all' : undefined}
+		>
+			{#if pagefindUrl !== '/'}
+				<span class="sr-only" data-pagefind-meta={`url:${pagefindUrl}`}></span>
+			{/if}
 			{@render children()}
 		</main>
 		<SiteFooter />

--- a/src/routes/api/status/+server.ts
+++ b/src/routes/api/status/+server.ts
@@ -1,0 +1,29 @@
+import { json } from '@sveltejs/kit';
+import { getBlueskyStatus } from '$lib/bluesky/status';
+import type { RequestHandler } from './$types';
+
+export const prerender = false;
+
+export const GET: RequestHandler = async () => {
+	try {
+		const status = await getBlueskyStatus();
+		return json(
+			{ status },
+			{
+				headers: {
+					'Cache-Control': 'public, max-age=60'
+				}
+			}
+		);
+	} catch {
+		return json(
+			{ status: null },
+			{
+				status: 503,
+				headers: {
+					'Cache-Control': 'no-store'
+				}
+			}
+		);
+	}
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig, type Plugin } from 'vite';
 
 const root = path.dirname(fileURLToPath(import.meta.url));
-const pagefindDir = path.join(root, 'build', 'pagefind');
+const pagefindDir = path.join(root, 'build', 'client', 'pagefind');
 
 const mimeTypes: Record<string, string> = {
 	'.js': 'application/javascript',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { defineConfig, type Plugin } from 'vite';
 
 const root = path.dirname(fileURLToPath(import.meta.url));
 const pagefindDir = path.join(root, 'build', 'client', 'pagefind');
+const pagefindIndexBuilt = fs.existsSync(path.join(pagefindDir, 'pagefind-entry.json'));
 
 const mimeTypes: Record<string, string> = {
 	'.js': 'application/javascript',
@@ -47,9 +48,12 @@ function pagefindDevPlugin(): Plugin {
 	};
 }
 
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
 	plugins: [sveltekit(), pagefindDevPlugin()],
+	define: {
+		__PAGEFIND_INDEX_BUILT__: JSON.stringify(mode === 'production' ? true : pagefindIndexBuilt)
+	},
 	ssr: {
 		external: ['better-sqlite3']
 	}
-});
+}));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a runtime `/api/status` endpoint that fetches a short "now" sentence from a Bluesky `com.michaelschultz.status/self` record, with a 60-second in-memory cache. The homepage hero displays the status via client fetch so it stays fresh without rebuilds.

Also switches from `adapter-static` to `adapter-node` for VPS deployment, updates Pagefind output paths for the new build layout, and adds a `pnpm status` CLI for publishing updates.

## API

`GET /api/status` returns:

```json
{ "status": { "text": "...", "createdAt": "...", "expiresAt": "..." } }
```

or `{ "status": null }` when no record exists or it has expired.

## Publishing a status

```bash
export BLUESKY_APP_PASSWORD=your-app-password
pnpm status "Shipping Hemolog 2.0"
```

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` succeeds with adapter-node and Pagefind indexing
- [x] `GET /api/status` returns `{"status":null}` when no record exists (verified locally)
- [x] Post first status with `pnpm status` and confirm `/api/status` + homepage hero update at runtime
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f1c67-9757-74c2-aa5d-2cdcad90e932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f1c67-9757-74c2-aa5d-2cdcad90e932"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

