### PR TITLE
Set up dev environment + document Cursor Cloud specifics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,10 @@
 - Node is locked to 24.x (`engines` in `package.json`, `.nvmrc`, `.node-version`).
 - Open Graph and Twitter meta come from `SocialMeta` in the root layout and `getPageSocialMeta` in `$lib/utils/social-meta.ts`; default image is `site.socialBanner` (`/static/images/michael-schultz-social.jpg`).
 - `pnpm check` runs `svelte-check` then `tsc --noEmit` so untyped route loaders are caught in CI and locally.
+
+## Cursor Cloud specific instructions
+
+- Node 24 is required (`engine-strict=true` in `.npmrc`); pnpm install will refuse to run on older Node. The VM has an `/exec-daemon/node` (Node 22) that shadows nvm on `PATH`, so run commands in a login shell (`bash -lc '...'`) where `~/.bashrc` puts nvm's Node 24 first. Verify with `node --version` before running pnpm.
+- Standard commands are in `README.md`/`package.json`: `pnpm dev` (Vite dev server on `http://localhost:5173`, routes use `trailingSlash: 'always'` so bare paths 308-redirect to the trailing-slash URL), `pnpm check`, `pnpm build` (also runs Pagefind indexing over `build/`), `pnpm start` (serves the built app on port 3000).
+- No secrets are needed to run/lint/build/test locally. Without `LASTFM_API_KEY` the `/listening` page renders normally but shows "No recent plays yet"; `pnpm status` (Bluesky) is a publishing script and not needed to run the site.
+- There is no automated test suite; `pnpm check` (svelte-check + tsc) is the type/lint gate and the `.husky/pre-commit` hook runs it on commit.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the development environment for this SvelteKit site, and documented durable Cursor Cloud setup caveats in `AGENTS.md`.

- Installed Node 24 (repo enforces `engine-strict` / Node 24.x) and pnpm deps (`better-sqlite3` native build succeeds).
- Verified type-checking, production build (incl. Pagefind indexing), and the Vite dev server end-to-end.
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` covering the Node 24 requirement, the `/exec-daemon/node` PATH shadowing gotcha (use a login shell), the standard run/build/check commands, and that no secrets are needed for local dev.

## Testing

- `pnpm check` — svelte-check + tsc, 0 errors
- `pnpm build` — Vite build + Pagefind (16 pages indexed)
- `pnpm dev` — dev server on `http://localhost:5173`, navigated homepage → work → thoughts → blog post → listening

[sveltekit_dev_site_walkthrough.mp4](https://cursor.com/agents/bc-d79da8ac-b9e2-40e6-8f9a-7388d7197e2b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsveltekit_dev_site_walkthrough.mp4)

[Homepage](https://cursor.com/agents/bc-d79da8ac-b9e2-40e6-8f9a-7388d7197e2b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Blog post](https://cursor.com/agents/bc-d79da8ac-b9e2-40e6-8f9a-7388d7197e2b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fblog_post.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d79da8ac-b9e2-40e6-8f9a-7388d7197e2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d79da8ac-b9e2-40e6-8f9a-7388d7197e2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

