### PR TITLE
Fix horizontal overflow on mobile viewports

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -58,6 +58,10 @@
   color utility to any element that depends on these defaults.
 */
 @layer base {
+	html {
+		overflow-x: clip;
+	}
+
 	*,
 	::after,
 	::before,
@@ -106,6 +110,10 @@
 	.prose-invert
 		:where(h1, h2, h3, h4, h5, h6):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
 		color: var(--color-gray-100);
+	}
+
+	.prose :where(iframe):not(:where([class~='not-prose'], [class~='not-prose'] *)) {
+		max-width: 100%;
 	}
 }
 

--- a/src/lib/components/MobileNav.svelte
+++ b/src/lib/components/MobileNav.svelte
@@ -6,14 +6,14 @@
 	function toggle() {
 		open = !open;
 		if (typeof document !== 'undefined') {
-			document.body.style.overflow = open ? 'hidden' : 'auto';
+			document.body.style.overflow = open ? 'hidden' : '';
 		}
 	}
 
 	function close() {
 		open = false;
 		if (typeof document !== 'undefined') {
-			document.body.style.overflow = 'auto';
+			document.body.style.overflow = '';
 		}
 	}
 </script>
@@ -37,7 +37,9 @@
 <div
 	class="fixed left-0 top-0 z-10 h-full w-full transform bg-white opacity-95 duration-300 ease-in-out dark:bg-gray-950 dark:opacity-[0.98] {open
 		? 'translate-x-0'
-		: 'translate-x-full'}"
+		: 'pointer-events-none translate-x-full'}"
+	aria-hidden={!open}
+	inert={!open}
 >
 	<div class="flex justify-end">
 		<button type="button" class="mr-8 mt-11 h-8 w-8" aria-label="Close Menu" onclick={close}>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -43,11 +43,11 @@
 	/>
 </svelte:head>
 
-<div class="mx-auto max-w-3xl px-4 sm:px-6 xl:max-w-5xl xl:px-0">
+<div class="mx-auto max-w-3xl overflow-x-clip px-4 sm:px-6 xl:max-w-5xl xl:px-0">
 	<div class="flex min-h-screen flex-col justify-between font-sans">
 		<SiteHeader onSearchClick={() => openSearch()} />
 		<main
-			class="mb-auto"
+			class="mb-auto min-w-0"
 			data-pagefind-body={pagefindUrl === '/' ? undefined : true}
 			data-pagefind-ignore={pagefindUrl === '/' ? 'all' : undefined}
 		>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,7 +14,7 @@
 	<meta name="description" content={site.description} />
 </svelte:head>
 
-<div class="relative">
+<div class="relative overflow-x-clip">
 	<div
 		class="absolute -left-60 top-20 h-[380px] w-[380px] animate-blob rounded-full bg-[#E2EFB0] opacity-5 blur-3xl"
 	></div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes horizontal panning on mobile (especially iPhone) by preventing page content from extending past the viewport width.

## Changes

- **`src/app.css`**: Add `overflow-x: clip` on `html` as a site-wide guard; constrain prose `iframe` embeds to `max-width: 100%`.
- **`src/routes/+page.svelte`**: Clip homepage decorative blobs with `overflow-x-clip` on their wrapper.
- **`src/lib/components/MobileNav.svelte`**: When the drawer is closed, disable pointer events and mark it `aria-hidden` / `inert`; reset body overflow to `''` instead of `'auto'`.
- **`src/routes/+layout.svelte`**: Add `overflow-x-clip` on the layout column and `min-w-0` on `<main>` for flex containment.

## Verification

- `pnpm check` passes
- Playwright checks at 375px and 390px viewports confirm no horizontal overflow on `/`, `/work/`, `/listening/`, `/games/`, and `/thoughts/pack-rat-game-jam/`
- Mobile nav open/close does not introduce horizontal scroll
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f2c23-911d-78ee-9720-2fae4bce91f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f2c23-911d-78ee-9720-2fae4bce91f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

